### PR TITLE
Add exit builtin, fix code formatting, add information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,137 @@
-s
-=
+# s
 
-simpler shell
+After the [Shellshock](https://en.wikipedia.org/wiki/Shellshock_(software_bug))
+bug happened they fixed the parsing bug in bash that let people hijack
+webservers by simply including `{ :; }`.
+
+Fixing a bug after it's been found is good but it doesn't have to be the end.
+Sometimes you think about the bigger picture and see if why it was ever a bug
+in the first place.
+
+I suspected that since bash syntax is very complex the parser is going to be a
+lot of complicated code too. So I did some line counts of various shells to
+what the situation is like:
+
+                  .c       .h
+    gnu bash:     138227,  13746
+    zsh:          135589,   5698
+    shivers scsh: 118475 (scheme)
+    templeos:     119115
+    mirbsd mksh:   29223,   2562
+    debian dash:   16503,   2084
+    freebsd sh:    15453,   1622
+    es shell:       9017,   1436
+    plan9 rc:       5989,    327
+    execline:       3794,    117
+
+The line count for templeos isn't just counting its shell. It's the linecount
+of the entire system: The operating system kernel, the compiler, the shell, the
+drawing program, the graphic user interface, the 3D flight simulator. **Bash,
+zsh and scsh have more code in them than an entire operating system.**
+
+Shell syntax being overcomplex and ideosyncratic is a long standing problem.
+Other than shellshock, annoyances happen on a daily basis. Like the time a bug
+in a bash script in steam rm -rf'd peoples home directory [Ran steam. It deleted everything](https://github.com/valvesoftware/steam-for-linux/issues/3671).
+I've had makefiles break a few times because there's a space in my path. It
+took these people four years to fix that [Build failure when builddir contains
+spaces](https://github.com/nodejs/node-gyp/issues/65).
+
+My idea to improve things is to use an extremely minimal shell with the
+simplest syntax possible.
+
+# The new command interpreter
+
+So I designed a new shell that aims to be extremely simple, and implemened it
+in a short number of lines of code. Right now it's 780 lines plus 1200 for the
+linenoise library. (Technically it is a "command interpreter" not a shell since
+shell implies it implements the POSIX shell standard).
+
+Here is the man page for *s*:
+
+```
+S(1)                        General Commands Manual                       S(1)
+
+NAME
+     s – command line interpreter
+
+SYNOPSIS
+     s [script]
+
+DESCRIPTION
+     s has two main modes of operation: interactive shell and batch script
+     processor.
+
+     If the command line argument script is provided it will execute that
+     file. This also allows you to use s as the shebang line in an executable.
+     Alternatively you can provide commands via stdin.
+
+     Otherwise if you start s in a terminal you will be given an interactive
+     shell prompt like this:
+
+             s$ echo hello world!
+             hello world!
+
+SYNTAX
+     The lexical syntax of the shell language is very strictly tokenized based
+     on spaces. Variables may occur inside tokens with ${FOO} syntax, the {}'s
+     are optional.
+
+     The # character starts a comment until the end of the line.
+
+     A token always stays a single token there is no globs or bash style
+     expansion. You will need to master xargs to use this shell.
+
+GRAMMAR
+     The grammar is line based. Sequences of tokens are treated as commands
+     and the operators | , && and || are parsed in order of tightest binding
+     first.
+
+     At the end of a line you can specify that job should be run in the
+     background with &
+
+
+BUILTINS
+     cd [directory]
+
+     set variable value
+
+     unset variable
+
+     source filename
+
+     If there is an error the builtins will cause the script to exit
+     immediately, in interactive mode a warning is printed.
+```
+
+The important thing is what's missing: We don't have globs or "splatting" where
+a variable `$FOO` turns into multiple command line arguments. One token stays
+one token forever. This is a "no surprises" straightforward approach.
+
+We don't even have redirection operators `>` in the shell language. They are
+added as extra programs. So you write `grep foo bar | > out.txt`. `>` is just
+another unix command. `<` is essentially `cat`. A `glob` program is also
+provided along with *s*, so you write `glob rm *`.
+
+The benefit of this extreme minimalism is that the implementation can be done
+with a very logical pipeline of operations: tokenizing splits the input based
+on spaces and expands the variables out, parsing looks for the operators and
+builds an AST, interpreting is a simple recursive walk down the AST
+implementing the various operators.
+
+* [tokenizer.c](https://github.com/rain-1/s/blob/master/tokenizer.c)
+* [variables.c](https://github.com/rain-1/s/blob/master/variables.c)
+* [parser.c](https://github.com/rain-1/s/blob/master/parser.c)
+* [interpreter.c](https://github.com/rain-1/s/blob/master/interpreter.c)
+* [repo](https://github.com/rain-1/s)
+
+# End
+
+What do you think? I would be very interested in hearing peoples opinions
+about *s* and the more general idea of stripping programs down to their
+essential parts. Feel free to comment or make 'issues' on the repo if you have
+any criticism, suggestions or just want to discuss.
+
+# See also
+
+* [execline](https://skarnet.org/software/execline/)
+

--- a/builtins.c
+++ b/builtins.c
@@ -42,44 +42,45 @@ void builtin_cd(char **args)
 {
 	char *dir;
 
-	if (!(dir = args[1])) {
+	if (!(dir = args[1]))
 		if (!(dir = getenv("HOME"))) {
 			report("invalid $HOME\n");
 			return;
 		}
-	}
 
 	if (chdir(dir)) {
 		report("could not change directory to [%s]\n", dir);
-	}
-	else {
+	} else {
 		getcwd(cwd, PATH_MAX);
 		setenv("PWD", cwd, 1);
 	}
 }
 
-void builtin_set(char **argv) {
+void builtin_set(char **argv)
+{
 	if (argv[1] && argv[2])
 		setenv(argv[1], argv[2], INT_MAX);
 	else
 		report("set requires two arguments\n");
 }
 
-void builtin_unset(char **argv) {
+void builtin_unset(char **argv)
+{
 	if (argv[1])
 		unsetenv(argv[1]);
 	else
 		report("unset requires an argument\n");
 }
 
-void builtin_source(char **argv) {
+void builtin_source(char **argv)
+{
 	FILE *f;
 	int mode;
 
 	if (!argv[1]) {
 		report("source requires an argument\n");
-	}
-	else if (!(f = fopen(argv[1], "r"))) {
+		return;
+	} else if (!(f = fopen(argv[1], "r"))) {
 		report("source open() failed\n");
 		return;
 	}

--- a/builtins.c
+++ b/builtins.c
@@ -28,6 +28,8 @@ int perform_builtin(struct AST *n)
 			builtin_unset(n->node.tokens);
 		else if (!strcmp("source", n->node.tokens[0]))
 			builtin_source(n->node.tokens);
+		else if (!strcmp("exit", n->node.tokens[0]))
+			builtin_exit(n->node.tokens);
 		else return 0;
 
 		return 1;
@@ -86,4 +88,12 @@ void builtin_source(char **argv) {
 	interactive_mode = 0;
 	loop(f);
 	interactive_mode = mode;
+}
+
+void builtin_exit(char **argv)
+{
+	if (!argv[1])
+		exit(0);
+	else
+		exit(strtol(argv[1], NULL, 0));
 }

--- a/builtins.h
+++ b/builtins.h
@@ -1,6 +1,7 @@
 int perform_builtin(struct AST *n);
 
-void builtin_cd(char **args);
-void builtin_set(char **args);
-void builtin_unset(char **args);
-void builtin_source(char **args);
+void builtin_cd(char **argv);
+void builtin_set(char **argv);
+void builtin_unset(char **argv);
+void builtin_source(char **argv);
+void builtin_exit(char **argv);

--- a/interpreter.c
+++ b/interpreter.c
@@ -31,11 +31,10 @@ void interpret_junction(struct AST* n)
 	pid_t p;
 	int r;
 
-	if (n->type == NODE_COMMAND) {
+	if (n->type == NODE_COMMAND)
 		interpret_command(n);
-	}
 
-	switch(p = fork()) {
+	switch (p = fork()) {
 	case -1: 
 		_reporterr("fork() failure");
 		break;
@@ -64,9 +63,8 @@ void interpret_junction(struct AST* n)
 
 void interpret_pipe(struct AST* n)
 {
-	if (n->type == NODE_COMMAND) {
+	if (n->type == NODE_COMMAND)
 		interpret_command(n);
-	}
 
 	int fd[2];
 	int f;
@@ -93,7 +91,7 @@ void interpret_pipe(struct AST* n)
 
 void interpret(struct AST* n)
 {
-	switch(n->type) {
+	switch (n->type) {
 	case NODE_COMMAND:
 		interpret_command(n);
 		break;
@@ -110,43 +108,42 @@ void interpret(struct AST* n)
 int prompt(string_port *port)
 {
 	char *line;
-	
+
 	if (interactive_mode) {
-		if((line = linenoise(geteuid() == 0 ? "s# " : "s$ ")) != NULL) {
+		if ((line = linenoise(geteuid() == 0 ? "s# " : "s$ "))) {
 			*port = (string_port){ .kind=STRPORT_CHAR, .text=line, .place=0 };
 			return 0;
 		}
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
-void loop(FILE *f) {
+void loop(FILE *f)
+{
 	pid_t p;
 	int bg;
 	region r;
 	struct AST* n;
 	int status;
-	
+
 	string_port port;
-	
-	if (!interactive_mode) {
+
+	if (!interactive_mode)
 		port = (string_port){ .kind=STRPORT_FILE, .fptr=f };
-	}
-	
-	
+
 	do {
-		if(prompt(&port)) {
-			if(feof(f))
+		if (prompt(&port)) {
+			if (feof(f))
 				break;
 			else
 				continue;
 		}
-		
+
 		region_create(&r);
-		
+
 		n = parse(&r, &port, &bg);
 
 		if (n && !perform_builtin(n)) {
@@ -155,9 +152,8 @@ void loop(FILE *f) {
 				_reporterr("== SHOULD NEVER GET HERE ==");
 			}
 
-			if (!bg) {
+			if (!bg)
 				waitpid(p, &status, 0);
-			}
 		}
 
 		region_free(&r);
@@ -166,9 +162,8 @@ void loop(FILE *f) {
 			// TODO: Only add if command was sucessful?
 			linenoiseHistoryAdd(port.text);
 			free(port.text);
-		}
-		else {
+		} else {
 			skip_newline(&port);
 		}
-	} while(!feof(f));
+	} while (!feof(f));
 }

--- a/parser.c
+++ b/parser.c
@@ -46,8 +46,7 @@ struct AST* parse_binop(region *r, char **tokens, NodeType ty)
 				return NULL;
 
 			return m;
-		}
-		else {
+		} else {
 			tokens++;
 		}
 	}
@@ -62,12 +61,11 @@ struct AST* parse_tokens(region *r, char **tokens, int *bg_flag)
 	while (tokens[i])
 		i++;
 
-        if (i > 0 && !strcmp("&", tokens[i-1])) {
-		*bg_flag=1;
+	if (i > 0 && !strcmp("&", tokens[i-1])) {
+		*bg_flag = 1;
 		tokens[--i] = NULL;
-	}
-	else {
-		*bg_flag=0;
+	} else {
+		*bg_flag = 0;
 	}
 
 	return parse_binop(r, tokens, NODE_DISJ);

--- a/region.c
+++ b/region.c
@@ -25,11 +25,9 @@ void* region_realloc(region *r, void *v, size_t size)
 {
 	int i;
 
-	for (i = 0; i < r->len; i++) {
-		if (r->pointers[i] == v) {
+	for (i = 0; i < r->len; i++)
+		if (r->pointers[i] == v)
 			return r->pointers[i] = realloc(r->pointers[i], size);
-		}
-	}
 
 	reporterr("Unable to realloc region [%p]", v);
 }
@@ -38,9 +36,8 @@ void region_free(region *r)
 {
 	int i;
 
-	for (i = 0; i < r->len; i++) {
+	for (i = 0; i < r->len; i++)
 		free(r->pointers[i]);
-	}
 
 	free(r->pointers);
 

--- a/stringport.c
+++ b/stringport.c
@@ -16,11 +16,9 @@ int fpeek(FILE *stream)
 
 int port_peek(string_port *port)
 {
-	switch(port->kind) {
-    
+	switch (port->kind) {
 	case STRPORT_CHAR:
 		return port->text[port->place];
-		break;
 
 	case STRPORT_FILE:
 		return fpeek(port->fptr);
@@ -32,11 +30,9 @@ int port_peek(string_port *port)
 
 int port_eof(string_port *port)
 {
-	switch(port->kind) {
-    
+	switch (port->kind) {
 	case STRPORT_CHAR:
 		return port->text[port->place] == '\0';
-		break;
 
 	case STRPORT_FILE:
 		return feof(port->fptr);
@@ -49,16 +45,14 @@ int port_eof(string_port *port)
 int port_getc(string_port *port)
 {
 	int c;
-  
-	switch(port->kind) {
-    
+
+	switch (port->kind) {
 	case STRPORT_CHAR:
 		c = port->text[port->place];
 
-		if(c != '\0') {
+		if (c != '\0')
 			port->place++;
-		}
-    
+
 		return c;
 
 	case STRPORT_FILE:

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -17,7 +17,7 @@ int token_end(int chr)
 void skip_spaces(string_port *stream)
 {
 	while (!port_eof(stream) && (port_peek(stream) == ' ' || port_peek(stream) == '\t'))
-	        port_getc(stream);
+		port_getc(stream);
 }
 
 void skip_newline(string_port *stream)
@@ -40,7 +40,7 @@ int token(string_port *stream)
 
 	char *buf;
 	int l;
-	
+
 	skip_spaces(stream);
 	if (port_eof(stream) || port_peek(stream) == '\n')
 		return -1;
@@ -84,9 +84,8 @@ char** read_tokens(region *r, string_port *f)
 	tokens = region_malloc(r, sizeof(char*)*MAX_TOKS_PER_LINE);
 
 	while ((t = token(f)) != -1) {
-		if (!(tokens[i] = expand_variables(r, tok_buf, t))) {
+		if (!(tokens[i] = expand_variables(r, tok_buf, t)))
 			return NULL;
-		}
 
 		i++;
 		if (i >= MAX_TOKS_PER_LINE) {

--- a/variables.c
+++ b/variables.c
@@ -46,8 +46,7 @@ char *expand_variables(region *r, char *tok, int t)
 			o = region_realloc(r, o, alloc_len);
 			memcpy(o + i, val, l);
 			i += l;
-		}
-		else {
+		} else {
 			o[i++] = *tok++;
 		}
 	}
@@ -100,6 +99,6 @@ char *read_variable_prefix(char *tok)
 		read_var_error = "length 0 variable";
 		return NULL;
 	}
-	
+
 	return tok;
 }


### PR DESCRIPTION
Run `exit` to quit `s`. Integer can be given as argument to change the exit code, default argument if none is given is `0`. Fixes #2

Fix code formatting to make is consistent and follow [the suckless coding style guide](http://suckless.org/coding_style)

`README.md` now contains useful information on the program based  @rain-1's blog post