### PR TITLE
Improve builtin selection, clean up reporting, fix exits, format functions

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -52,15 +52,11 @@ builtin_cd(char **args)
 	int isowd = 0;
 
 	if (!(dir = args[1])) {
-		if (!(dir = getenv("HOME"))) {
-			report("invalid $HOME");
-			return;
-		}
+		if (!(dir = getenv("HOME")))
+			reportret(,"invalid $HOME");
 	} else if (strcmp(dir, "-") == 0) {
-		if (!(dir = getenv("OLDPWD"))) {
-			report("invalid $OLDPWD");
-			return;
-		}
+		if (!(dir = getenv("OLDPWD")))
+			reportret(,"invalid $OLDPWD");
 		isowd = 1;
 	}
 
@@ -100,13 +96,10 @@ builtin_source(char **argv)
 	FILE *f;
 	int mode;
 
-	if (!argv[1]) {
-		report("source requires an argument");
-		return;
-	} else if (!(f = fopen(argv[1], "r"))) {
-		report("source open() failed");
-		return;
-	}
+	if (!argv[1])
+		reportret(,"source requires an argument");
+	if (!(f = fopen(argv[1], "r")))
+		reportret(,"source open() failed");
 
 	mode = interactive_mode;
 	interactive_mode = 0;

--- a/builtins.c
+++ b/builtins.c
@@ -15,25 +15,30 @@
 #include "interpreter.h"
 #include "builtins.h"
 
+#define LEN(X) (sizeof(X) / sizeof((X)[0]))
+
 char cwd[PATH_MAX];
+
+Builtin builtins[] = {
+	{ "cd",     &builtin_cd },
+	{ "set",    &builtin_set },
+	{ "unset",  &builtin_unset },
+	{ "source", &builtin_source },
+	{ "exit",   &builtin_exit }
+};
 
 int perform_builtin(struct AST *n)
 {
-	if (n->type == NODE_COMMAND && n->node.tokens[0]) {
-		if (!strcmp("cd", n->node.tokens[0]))
-			builtin_cd(n->node.tokens);
-		else if (!strcmp("set", n->node.tokens[0]))
-			builtin_set(n->node.tokens);
-		else if (!strcmp("unset", n->node.tokens[0]))
-			builtin_unset(n->node.tokens);
-		else if (!strcmp("source", n->node.tokens[0]))
-			builtin_source(n->node.tokens);
-		else if (!strcmp("exit", n->node.tokens[0]))
-			builtin_exit(n->node.tokens);
-		else return 0;
+	int i;
 
-		return 1;
-	}
+	if (n->type != NODE_COMMAND || !n->node.tokens[0])
+		return 0;
+
+	for (i = 0; i < LEN(builtins); i++)
+		if (!strcmp(builtins[i].name, n->node.tokens[0])) {
+			(*builtins[i].func)(n->node.tokens);
+			return 1;
+		}
 
 	return 0;
 }

--- a/builtins.c
+++ b/builtins.c
@@ -49,12 +49,12 @@ void builtin_cd(char **args)
 
 	if (!(dir = args[1]))
 		if (!(dir = getenv("HOME"))) {
-			report("invalid $HOME\n");
+			report("invalid $HOME");
 			return;
 		}
 
 	if (chdir(dir)) {
-		report("could not change directory to [%s]\n", dir);
+		report("could not change directory to [%s]", dir);
 	} else {
 		getcwd(cwd, PATH_MAX);
 		setenv("PWD", cwd, 1);
@@ -66,7 +66,7 @@ void builtin_set(char **argv)
 	if (argv[1] && argv[2])
 		setenv(argv[1], argv[2], INT_MAX);
 	else
-		report("set requires two arguments\n");
+		report("set requires two arguments");
 }
 
 void builtin_unset(char **argv)
@@ -74,7 +74,7 @@ void builtin_unset(char **argv)
 	if (argv[1])
 		unsetenv(argv[1]);
 	else
-		report("unset requires an argument\n");
+		report("unset requires an argument");
 }
 
 void builtin_source(char **argv)
@@ -83,10 +83,10 @@ void builtin_source(char **argv)
 	int mode;
 
 	if (!argv[1]) {
-		report("source requires an argument\n");
+		report("source requires an argument");
 		return;
 	} else if (!(f = fopen(argv[1], "r"))) {
-		report("source open() failed\n");
+		report("source open() failed");
 		return;
 	}
 

--- a/builtins.c
+++ b/builtins.c
@@ -27,7 +27,8 @@ Builtin builtins[] = {
 	{ "exit",   &builtin_exit }
 };
 
-int perform_builtin(struct AST *n)
+int
+perform_builtin(struct AST *n)
 {
 	int i;
 
@@ -43,7 +44,8 @@ int perform_builtin(struct AST *n)
 	return 0;
 }
 
-void builtin_cd(char **args)
+void
+builtin_cd(char **args)
 {
 	char *dir;
 
@@ -61,7 +63,8 @@ void builtin_cd(char **args)
 	}
 }
 
-void builtin_set(char **argv)
+void
+builtin_set(char **argv)
 {
 	if (argv[1] && argv[2])
 		setenv(argv[1], argv[2], INT_MAX);
@@ -69,7 +72,8 @@ void builtin_set(char **argv)
 		report("set requires two arguments");
 }
 
-void builtin_unset(char **argv)
+void
+builtin_unset(char **argv)
 {
 	if (argv[1])
 		unsetenv(argv[1]);
@@ -77,7 +81,8 @@ void builtin_unset(char **argv)
 		report("unset requires an argument");
 }
 
-void builtin_source(char **argv)
+void
+builtin_source(char **argv)
 {
 	FILE *f;
 	int mode;
@@ -96,7 +101,8 @@ void builtin_source(char **argv)
 	interactive_mode = mode;
 }
 
-void builtin_exit(char **argv)
+void
+builtin_exit(char **argv)
 {
 	if (!argv[1])
 		exit(0);

--- a/builtins.h
+++ b/builtins.h
@@ -1,3 +1,8 @@
+typedef struct {
+	char *name;
+	void (*func)(char **);
+} Builtin;
+
 int perform_builtin(struct AST *n);
 
 void builtin_cd(char **argv);

--- a/interpreter.c
+++ b/interpreter.c
@@ -17,7 +17,8 @@
 
 int interactive_mode = 0;
 
-void interpret_command(struct AST* n)
+void
+interpret_command(struct AST* n)
 {
 	assert(n->type == NODE_COMMAND);
 
@@ -26,7 +27,8 @@ void interpret_command(struct AST* n)
 	_reporterr("Error: Could not execute the program named [%s]", n->node.tokens[0]);
 }
 
-void interpret_junction(struct AST* n)
+void
+interpret_junction(struct AST* n)
 {
 	pid_t p;
 	int r;
@@ -61,7 +63,8 @@ void interpret_junction(struct AST* n)
 	}
 }
 
-void interpret_pipe(struct AST* n)
+void
+interpret_pipe(struct AST* n)
 {
 	if (n->type == NODE_COMMAND)
 		interpret_command(n);
@@ -89,7 +92,8 @@ void interpret_pipe(struct AST* n)
 	}
 }
 
-void interpret(struct AST* n)
+void
+interpret(struct AST* n)
 {
 	switch (n->type) {
 	case NODE_COMMAND:
@@ -105,7 +109,8 @@ void interpret(struct AST* n)
 	}
 }
 
-int prompt(string_port *port)
+int
+prompt(string_port *port)
 {
 	char *line;
 
@@ -121,7 +126,8 @@ int prompt(string_port *port)
 	return 0;
 }
 
-void loop(FILE *f)
+void
+loop(FILE *f)
 {
 	pid_t p;
 	int bg;

--- a/interpreter.c
+++ b/interpreter.c
@@ -23,7 +23,7 @@ void interpret_command(struct AST* n)
 
 	execvp(n->node.tokens[0], n->node.tokens);
 
-	_reporterr("Error: Could not execute the program named [%s]\n", n->node.tokens[0]);
+	_reporterr("Error: Could not execute the program named [%s]", n->node.tokens[0]);
 }
 
 void interpret_junction(struct AST* n)

--- a/parser.c
+++ b/parser.c
@@ -24,10 +24,8 @@ parse_binop(region *r, char **tokens, NodeType ty)
 	stokens = tokens;
 
 	if (ty == NODE_COMMAND) {
-		if (!tokens[0]) {
-			report("Error: bad syntax, zero-length command");
-			return NULL;
-		}
+		if (!tokens[0])
+			reportret(NULL, "Error: bad syntax, zero-length command");
 		n = region_malloc(r, sizeof(struct AST));
 		n->type = NODE_COMMAND;
 		n->node.tokens = stokens;

--- a/parser.c
+++ b/parser.c
@@ -14,7 +14,8 @@ char *operator_for[] = {
 	[NODE_DISJ] = "||",
 };
 
-struct AST* parse_binop(region *r, char **tokens, NodeType ty)
+struct AST *
+parse_binop(region *r, char **tokens, NodeType ty)
 {
 	char **stokens;
 	struct AST* n;
@@ -54,7 +55,8 @@ struct AST* parse_binop(region *r, char **tokens, NodeType ty)
 	return parse_binop(r, stokens, ty-1);
 }
 
-struct AST* parse_tokens(region *r, char **tokens, int *bg_flag)
+struct AST *
+parse_tokens(region *r, char **tokens, int *bg_flag)
 {
 	int i = 0;
 
@@ -71,7 +73,8 @@ struct AST* parse_tokens(region *r, char **tokens, int *bg_flag)
 	return parse_binop(r, tokens, NODE_DISJ);
 }
 
-struct AST* parse(region *r, string_port *port, int *bg_flag)
+struct AST *
+parse(region *r, string_port *port, int *bg_flag)
 {
 	char **tokens = read_tokens(r, port);
 

--- a/parser.c
+++ b/parser.c
@@ -24,7 +24,7 @@ struct AST* parse_binop(region *r, char **tokens, NodeType ty)
 
 	if (ty == NODE_COMMAND) {
 		if (!tokens[0]) {
-			report("Error: bad syntax, zero-length command\n");
+			report("Error: bad syntax, zero-length command");
 			return NULL;
 		}
 		n = region_malloc(r, sizeof(struct AST));

--- a/region.c
+++ b/region.c
@@ -4,14 +4,16 @@
 #include "region.h"
 #include "reporting.h"
 
-void region_create(region *r)
+void
+region_create(region *r)
 {
 	r->len = 0;
 	r->alloc_len = 2;
 	r->pointers = malloc(sizeof(void*)*r->alloc_len);
 }
 
-void* region_malloc(region *r, size_t size)
+void *
+region_malloc(region *r, size_t size)
 {
 	if (r->len >= r->alloc_len) {
 		r->alloc_len <<= 1;
@@ -21,7 +23,8 @@ void* region_malloc(region *r, size_t size)
 	return r->pointers[r->len++] = malloc(size);
 }
 
-void* region_realloc(region *r, void *v, size_t size)
+void *
+region_realloc(region *r, void *v, size_t size)
 {
 	int i;
 

--- a/reporting.h
+++ b/reporting.h
@@ -1,6 +1,6 @@
 
 extern int interactive_mode;
 
-#define reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); exit(-1);}
-#define _reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); _exit(-1);}
-#define report(M, ...) {fprintf(stderr, "%s (%s:%d) " M "\n", interactive_mode ? "Warning" : "Error", __FILE__, __LINE__, ##__VA_ARGS__); if (!interactive_mode) exit(-1);}
+#define reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); exit(1);}
+#define _reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); _exit(1);}
+#define report(M, ...) {fprintf(stderr, "%s (%s:%d) " M "\n", interactive_mode ? "Warning" : "Error", __FILE__, __LINE__, ##__VA_ARGS__); if (!interactive_mode) exit(1);}

--- a/reporting.h
+++ b/reporting.h
@@ -1,6 +1,23 @@
 
 extern int interactive_mode;
 
-#define reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); exit(1);}
-#define _reporterr(M, ...) {fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); _exit(1);}
-#define report(M, ...) {fprintf(stderr, "%s (%s:%d) " M "\n", interactive_mode ? "Warning" : "Error", __FILE__, __LINE__, ##__VA_ARGS__); if (!interactive_mode) exit(1);}
+#define reporterr(M, ...) { \
+	fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+	exit(1); \
+}
+#define _reporterr(M, ...) { \
+	fprintf(stderr, "Error (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+	_exit(1); \
+}
+#define reportret(R, M, ...) { \
+	fprintf(stderr, "%s (%s:%d) " M "\n", interactive_mode ? "Warning" : "Error", __FILE__, __LINE__, ##__VA_ARGS__); \
+	if (!interactive_mode) \
+		exit(1); \
+	else \
+		return R; \
+}
+#define report(M, ...) { \
+	fprintf(stderr, "%s (%s:%d) " M "\n", interactive_mode ? "Warning" : "Error", __FILE__, __LINE__, ##__VA_ARGS__); \
+	if (!interactive_mode) \
+		exit(1); \
+}

--- a/s.c
+++ b/s.c
@@ -33,10 +33,8 @@ int main(int argc, char **argv)
 	}
 	else {
 		f = fopen(argv[1], "r");
-		if (!f) {
+		if (!f)
 			reporterr("Could not open file <%s>!", argv[1]);
-			exit(-1);
-		}
 
 		interactive_mode = 0;
 	}

--- a/s.c
+++ b/s.c
@@ -33,9 +33,8 @@ main(int argc, char **argv)
 
 		interactive_mode = isatty(fileno(stdin));
 	} else {
-		f = fopen(argv[1], "r");
-		if (!f)
-			reporterr("Could not open file <%s>!", argv[1]);
+		if (!(f = fopen(argv[1], "r")))
+			reporterr("Could not open file [%s]!", argv[1]);
 
 		interactive_mode = 0;
 	}

--- a/s.c
+++ b/s.c
@@ -13,11 +13,13 @@
 #include "interpreter.h"
 #include "builtins.h"
 
-void handler_sigint(int sig) {
+void
+handler_sigint(int sig) {
   //signal(sig, SIG_IGN);
 }
 
-int main(int argc, char **argv)
+int
+main(int argc, char **argv)
 {
 	int i;
 	FILE *f;
@@ -30,8 +32,7 @@ int main(int argc, char **argv)
 		f = stdin;
 
 		interactive_mode = isatty(fileno(stdin));
-	}
-	else {
+	} else {
 		f = fopen(argv[1], "r");
 		if (!f)
 			reporterr("Could not open file <%s>!", argv[1]);

--- a/stringport.c
+++ b/stringport.c
@@ -4,7 +4,8 @@
 #include "stringport.h"
 
 // from stackoverflow.com/questions/2082743/c-equivalent-to-fstreams-peek
-int fpeek(FILE *stream)
+int
+fpeek(FILE *stream)
 {
 	int c;
 
@@ -14,7 +15,8 @@ int fpeek(FILE *stream)
 	return c;
 }
 
-int port_peek(string_port *port)
+int
+port_peek(string_port *port)
 {
 	switch (port->kind) {
 	case STRPORT_CHAR:
@@ -24,11 +26,12 @@ int port_peek(string_port *port)
 		return fpeek(port->fptr);
 
 	default:
-		exit(-1);
+		exit(1);
 	}
 }
 
-int port_eof(string_port *port)
+int
+port_eof(string_port *port)
 {
 	switch (port->kind) {
 	case STRPORT_CHAR:
@@ -38,11 +41,12 @@ int port_eof(string_port *port)
 		return feof(port->fptr);
 
 	default:
-		exit(-1);
+		exit(1);
 	}
 }
 
-int port_getc(string_port *port)
+int
+port_getc(string_port *port)
 {
 	int c;
 
@@ -59,6 +63,6 @@ int port_getc(string_port *port)
 		return fgetc(port->fptr);
 
 	default:
-		exit(-1);
+		exit(1);
 	}
 }

--- a/supporting/glob.c
+++ b/supporting/glob.c
@@ -4,41 +4,41 @@
 #include <glob.h>
 #include <unistd.h>
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv)
+{
 	int i;
 	glob_t g;
 	int res;
 
 	argc--;
 	argv++;
-	
+
 	g.gl_offs = 0;
-	
+
 	for (i = 0; i < argc; i++) {
-	  res = glob(argv[i], GLOB_DOOFFS | (i ? GLOB_APPEND : 0) | (strchr(argv[i], '*') ? 0 : GLOB_NOCHECK), NULL, &g);
-	  if(!res) {
-	    if(res == GLOB_NOSPACE) {
-	      fprintf(stderr, "glob: GLOB_NOSPACE - running out of memory\n");
-	      return -1;
-	    }
-	    else if(res == GLOB_ABORTED) {
-	      fprintf(stderr, "glob: GLOB_ABORTED - read error\n");
-	      return -1;
-	    }
-	    else if(res == GLOB_NOMATCH) {
-	      fprintf(stderr, "glob: GLOB_NOMATCH - no matches\n");
-	      return -1;
-	    }
-	  }
+		res = glob(argv[i], GLOB_DOOFFS | (i ? GLOB_APPEND : 0) | (strchr(argv[i], '*') ? 0 : GLOB_NOCHECK), NULL, &g);
+		if (!res) {
+			if (res == GLOB_NOSPACE) {
+				fprintf(stderr, "glob: GLOB_NOSPACE - running out of memory\n");
+				return EXIT_FAILURE;
+			} else if (res == GLOB_ABORTED) {
+				fprintf(stderr, "glob: GLOB_ABORTED - read error\n");
+				return EXIT_FAILURE;
+			} else if (res == GLOB_NOMATCH) {
+				fprintf(stderr, "glob: GLOB_NOMATCH - no matches\n");
+				return EXIT_FAILURE;
+			}
+		}
 	}
 
-        if(!g.gl_pathv[0]) {
-	  fprintf(stderr, "glob: NULL\n");
-	  return -1;
+	if (!g.gl_pathv[0]) {
+		fprintf(stderr, "glob: NULL\n");
+		return EXIT_FAILURE;
 	}
-	
+
 	execvp(g.gl_pathv[0], g.gl_pathv);
 
 	fprintf(stderr, "Error: could not execute %s\n", g.gl_pathv[0]);
-	return 1;
+	return EXIT_FAILURE;
 }

--- a/supporting/redir-box.c
+++ b/supporting/redir-box.c
@@ -10,7 +10,9 @@ char buf[BUF_SIZE];
 
 enum { lt, gt, gtgt };
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv)
+{
 	int mode, s;
 	char *flags;
 	FILE *fin, *fout, *ftmp;
@@ -59,9 +61,8 @@ int main(int argc, char **argv) {
 	do {
 		s = fread(buf, 1, BUF_SIZE, fin);
 
-		if (fwrite(buf, 1, s, fout) != s) {
+		if (fwrite(buf, 1, s, fout) != s)
 			fprintf(stderr, "Writing error\n");
-		}
 	} while(s != -1 && s != 0);
 
 	fclose(fout);

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -9,18 +9,21 @@
 
 char tok_buf[TOK_MAX];
 
-int token_end(int chr)
+int
+token_end(int chr)
 {
 	return chr == ' ' || chr == '\t' || chr == '\n' || chr == '#';
 }
 
-void skip_spaces(string_port *stream)
+void
+skip_spaces(string_port *stream)
 {
 	while (!port_eof(stream) && (port_peek(stream) == ' ' || port_peek(stream) == '\t'))
 		port_getc(stream);
 }
 
-void skip_newline(string_port *stream)
+void
+skip_newline(string_port *stream)
 {
 	skip_spaces(stream);
 	if (port_peek(stream) == '\n')
@@ -29,12 +32,14 @@ void skip_newline(string_port *stream)
 		return;
 }
 
-void skip_comment(string_port *stream)
+void
+skip_comment(string_port *stream)
 {
 	while (!port_eof(stream) && port_getc(stream) != '\n');
 }
 
-int token(string_port *stream)
+int
+token(string_port *stream)
 {
 	// TODO strings
 
@@ -72,7 +77,8 @@ int token(string_port *stream)
 	return l;
 }
 
-char** read_tokens(region *r, string_port *f)
+char **
+read_tokens(region *r, string_port *f)
 {
 	char **tokens;
 	int i, t;

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -58,10 +58,8 @@ int token(string_port *stream)
 				reporterr("end of file when interpreting \\");
 		}
 		l++;
-		if (l >= TOK_MAX-1) {
+		if (l >= TOK_MAX-1)
 			reporterr("Token too long!");
-			exit(-1);
-		}
 	}
 	buf[l] = '\0';
 
@@ -88,10 +86,8 @@ char** read_tokens(region *r, string_port *f)
 			return NULL;
 
 		i++;
-		if (i >= MAX_TOKS_PER_LINE) {
-			reporterr("Line too long!\n");
-			exit(-1);
-		}
+		if (i >= MAX_TOKS_PER_LINE)
+			reporterr("Line too long!");
 	}
 
 	tokens[i] = NULL;

--- a/variables.c
+++ b/variables.c
@@ -12,7 +12,8 @@
 char variable_name[TOK_MAX];
 char *read_var_error;
 
-char *expand_variables(region *r, char *tok, int t)
+char *
+expand_variables(region *r, char *tok, int t)
 {
 	char *stok, *o, *val;
 	int alloc_len;
@@ -55,12 +56,14 @@ char *expand_variables(region *r, char *tok, int t)
 	return o;
 }
 
-int variable_character(char c)
+int
+variable_character(char c)
 {
 	return c == '_' || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9');
 }
 
-char *read_variable_prefix(char *tok)
+char *
+read_variable_prefix(char *tok)
 {
 	int i;
 	int bracket;

--- a/variables.c
+++ b/variables.c
@@ -26,12 +26,12 @@ char *expand_variables(region *r, char *tok, int t)
 	while (*tok) {
 		if (*tok == '$') {
 			if (!(tok = read_variable_prefix(tok))) {
-				report("Problem parsing variable inside token [%s] at character [%d]. %s.\n", stok, i, read_var_error);
+				report("Problem parsing variable inside token [%s] at character [%d]. %s.", stok, i, read_var_error);
 				return NULL;
 			}
 
 			if (!(val = getenv(variable_name))) {
-				report("Reference to an undefined variable inside token [%s] at character [%d]\n", stok, i);
+				report("Reference to an undefined variable inside token [%s] at character [%d]", stok, i);
 				return NULL;
 			}
 


### PR DESCRIPTION
The new `Builtin` struct contains the name of the builtin as a string and a function pointer which should run when the builtin is called. An array of this struct is used to store all the available builtins with each one's name and respective function. Removes repetition in needing to use if else statements for every builtin.

Add $OLDPWD support for `cd` builtin. Passing argument of `-` to `cd` now changes directories to $OLDPWD, the previous working directory, which is also now set in `cd`.

Fix use of `report` since it already adds a newline character and already calls `exit`. Also add `reportret` for returning a value (or nothing if the function is `void`) instead of calling `exit`.

Fix more exits to return 1, not -1

Format code in the supporting folder and change functions so that their return type is own their own line, following [suckless style](http://suckless.org/coding_style)