### PR TITLE
Add positional parameters, fix memory leaks

### DIFF
--- a/arg.h
+++ b/arg.h
@@ -9,7 +9,7 @@
 extern char *argv0;
 
 /* use main(int argc, char *argv[]) */
-#define ARGBEGIN	for (argv0 = *argv, argv++, argc--;\
+#define ARGBEGIN	for (argv0 = basename(*argv), argv++, argc--;\
 					argv[0] && argv[0][0] == '-'\
 					&& argv[0][1];\
 					argc--, argv++) {\

--- a/builtins.c
+++ b/builtins.c
@@ -13,6 +13,7 @@
 #include "reporting.h"
 #include "region.h"
 #include "stringport.h"
+#include "tokenizer.h"
 #include "variables.h"
 #include "parser.h"
 #include "interpreter.h"

--- a/builtins.c
+++ b/builtins.c
@@ -13,6 +13,7 @@
 #include "reporting.h"
 #include "region.h"
 #include "stringport.h"
+#include "variables.h"
 #include "parser.h"
 #include "interpreter.h"
 #include "builtins.h"
@@ -59,6 +60,8 @@ builtin_source(char **argv)
 
 	mode = interactive_mode;
 	interactive_mode = 0;
+
+	vars_set(argv);
 
 	interpreter_loop(f);
 

--- a/builtins.c
+++ b/builtins.c
@@ -60,8 +60,6 @@ builtin_source(char **argv)
 	mode = interactive_mode;
 	interactive_mode = 0;
 
-	vars_set(argv);
-
 	interpreter_loop(f);
 
 	interactive_mode = mode;

--- a/interpreter.c
+++ b/interpreter.c
@@ -241,5 +241,7 @@ interpreter_loop(FILE *f)
 		}
 	} while (!feof(f));
 
+	fclose(f);
+
 	vars_unset();
 }

--- a/interpreter.c
+++ b/interpreter.c
@@ -41,7 +41,7 @@ interpret_junction(struct AST* n)
 		interpret_command(n);
 
 	switch (p = fork()) {
-	case -1: 
+	case -1:
 		_reporterr("fork() failure");
 		break;
 	case 0:

--- a/interpreter.c
+++ b/interpreter.c
@@ -12,6 +12,7 @@
 #include "region.h"
 #include "stringport.h"
 #include "tokenizer.h"
+#include "variables.h"
 #include "parser.h"
 #include "interpreter.h"
 #include "builtins.h"
@@ -239,4 +240,6 @@ interpreter_loop(FILE *f)
 			skip_newline(&port);
 		}
 	} while (!feof(f));
+
+	vars_unset();
 }

--- a/parser.c
+++ b/parser.c
@@ -16,7 +16,7 @@ char *operator_for[] = {
 	[NODE_DISJ] = "||",
 };
 
-struct AST *
+static struct AST *
 parse_binop(region *r, char **toks, NodeType ty)
 {
 	char **stoks = toks;
@@ -53,7 +53,7 @@ parse_binop(region *r, char **toks, NodeType ty)
 	return parse_binop(r, stoks, ty-1);
 }
 
-struct AST *
+static struct AST *
 parse_tokens(region *r, char **toks, int *bg)
 {
 	int tokc = 0;

--- a/parser.h
+++ b/parser.h
@@ -20,7 +20,4 @@ struct AST {
 
 extern char *operator_for[];
 
-struct AST* parse_tokens(region *r, char **tokens, int *bg_flag);
-
 struct AST* parse(region *r, string_port *port, int *bg_flag);
-

--- a/parser.h
+++ b/parser.h
@@ -20,4 +20,4 @@ struct AST {
 
 extern char *operator_for[];
 
-struct AST* parse(region *r, string_port *port, int *bg_flag);
+struct AST *parse(region *r, string_port *port, int *bg_flag);

--- a/s.c
+++ b/s.c
@@ -68,5 +68,7 @@ main(int argc, char **argv)
 
 	interpreter_loop(f);
 
+	fclose(f);
+
 	return 0;
 }

--- a/s.c
+++ b/s.c
@@ -1,5 +1,6 @@
 /* see LICENSE file for copyright and license details */
 /* command line interpreter */
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/s.c
+++ b/s.c
@@ -71,7 +71,5 @@ main(int argc, char **argv)
 
 	interpreter_loop(f);
 
-	fclose(f);
-
 	return 0;
 }

--- a/s.c
+++ b/s.c
@@ -13,6 +13,7 @@
 #include "reporting.h"
 #include "stringport.h"
 #include "tokenizer.h"
+#include "variables.h"
 #include "parser.h"
 #include "interpreter.h"
 #include "builtins.h"
@@ -62,6 +63,8 @@ main(int argc, char **argv)
 	} else {
 		if (!(f = fopen(argv[1], "r")))
 			reporterr("source: %s: could not load file", argv[1]);
+
+		vars_set(argv);
 
 		interactive_mode = 0;
 	}

--- a/stringport.c
+++ b/stringport.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "stringport.h"
+#include "reporting.h"
 
 int
 port_peek(string_port *port)
@@ -15,9 +16,8 @@ port_peek(string_port *port)
 		c = fgetc(port->fptr);
 		ungetc(c, port->fptr);
 		return c;
-	default:
-		exit(1);
 	}
+	reporterr("port set to wrong kind");
 }
 
 int
@@ -28,9 +28,8 @@ port_eof(string_port *port)
 		return port->text[port->place] == '\0';
 	case STRPORT_FILE:
 		return feof(port->fptr);
-	default:
-		exit(1);
 	}
+	reporterr("port set to wrong kind");
 }
 
 int
@@ -46,7 +45,6 @@ port_getc(string_port *port)
 		return c;
 	case STRPORT_FILE:
 		return fgetc(port->fptr);
-	default:
-		exit(1);
 	}
+	reporterr("port set to wrong kind");
 }

--- a/stringport.h
+++ b/stringport.h
@@ -1,10 +1,9 @@
 /* see LICENSE file for copyright and license details */
 
-#define STRPORT_CHAR 0
-#define STRPORT_FILE 1
+typedef enum { STRPORT_CHAR, STRPORT_FILE } Strport;
 
 typedef struct {
-  int kind;
+  Strport kind;
 
   /* kind=STRPORT_CHAR */
   char *text;

--- a/t/expect/args.txt
+++ b/t/expect/args.txt
@@ -1,0 +1,2 @@
+tmp.s foo bar 2
+tmp.s cat dog 3

--- a/t/scripts/args.s
+++ b/t/scripts/args.s
@@ -1,0 +1,4 @@
+echo 'echo $0 $1 $2 $#' | > tmp.s
+source tmp.s foo bar
+source tmp.s cat dog fish
+rm -f tmp.s

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -206,7 +206,7 @@ read_tokens(region *r, string_port *stream)
 			break;
 		case EXPAND_EVAL:
 			port = (string_port){ .kind=STRPORT_CHAR, .text=tok_buf, .place=0 };
-			if (!parse_and_execute(&port, &result))
+			if (!parse_and_execute(&port, &result)) /* TODO fix result memory leak */
 				tokens[i] = result;
 			else {
 				efree(result);

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -19,24 +19,24 @@ enum {
 	EXPAND_EVAL,
 };
 
-static int
-is_quote_char(int chr)
-{
-	return chr == '"' || chr == '\'' || chr == '`';
-}
+char escs[][2] = {
+	{ '\\', '\\' },
+	{ 't',  '\t' },
+	{ 'n',  '\n' },
+	{ 'r',  '\r' },
+	{ '"',  '"'  },
+	{ '\'', '\'' },
+	{ '`',  '`'  }
+};
 
 static int
-is_escape_char(int chr)
+is_esc(int c)
 {
-	return chr == '\\' || chr == 't' || chr == 'n' || chr == 'r' ||
-	       is_quote_char(chr);
-}
-
-static int
-token_end(int chr)
-{
-	return chr == ' ' || chr == '\t' || chr == '\n' || chr == '\r' ||
-	       chr == '#';
+	int i;
+	for (i = 0; i < LEN(escs); i++)
+		if (escs[i][0] == c)
+			return 1;
+	return 0;
 }
 
 static void
@@ -69,18 +69,15 @@ skip_newline(string_port *stream)
 
 /* returns -1 on failure, length of the token on success
  * a word token cannot have length 0 but a string token can */
-int
+static int
 read_token(char *tok_buf, string_port *stream, int *out_should_expand)
 {
-	int len = 0;
-	char c;
+	int len = 0, escape_char, i;
+	char c, quote;
 
-	char quote;
-	int escape_char;
-
-/* TOK(c) adds a character c to the buffer, erroring if we went over the limit */
+/* TOK(c) adds a character c to the buffer, erroring if it went over the limit */
 #define TOK(c)					\
-	if (len >= TOK_MAX-1)			\
+	if (len > TOK_MAX)			\
 		reporterr("token too long");	\
 	tok_buf[len++] = c
 
@@ -100,7 +97,7 @@ st_restart:
 st_tok:
 	c = port_getc(stream);
 
-	if (is_quote_char(c)) {
+	if (is_quote(c)) {
 		quote = c;
 		escape_char = 0;
 
@@ -123,8 +120,7 @@ st_tok:
 		if (port_peek(stream) == '\n') {
 			port_getc(stream);
 			goto st_restart;
-		}
-		else
+		} else
 			goto st_word;
 	} else {
 		goto st_word;
@@ -141,7 +137,7 @@ st_word:
 	TOK(c);
 
 st_word_continue:
-	if (port_eof(stream) || token_end(port_peek(stream))) {
+	if (port_eof(stream) || is_eot(port_peek(stream))) {
 		if (len)
 			goto st_accept;
 		else
@@ -151,7 +147,7 @@ st_word_continue:
 
 		goto st_word;
 	}
-	
+
 st_string:
 	if (port_eof(stream))
 		return -1;
@@ -159,41 +155,21 @@ st_string:
 	c = port_getc(stream);
 	if (!escape_char && c == quote) {
 		/* check that the very next char is not another string */
-		if (is_quote_char(port_peek(stream)))
+		if (is_quote(port_peek(stream)))
 			reportret(-2, "strings too close together");
 
 		goto st_accept;
 	} else if (!escape_char && c == '\\') {
 		escape_char = 1;
 		goto st_string;
-	} else if (escape_char && is_escape_char(c)) {
+	} else if (escape_char && is_esc(c)) {
 		escape_char = 0;
-		switch(c) {
-		case '\\':
-			TOK('\\');
-			break;
-		case 't':
-			TOK('\t');
-			break;
-		case 'n':
-			TOK('\n');
-			break;
-		case 'r':
-			TOK('\r');
-			break;
-		case '"':
-			TOK('"');
-			break;
-		case '\'':
-			TOK('\'');
-			break;
-		case '`':
-			TOK('`');
-			break;
-		default:
-			reportret(-2, "impossible escape");
-		}
-		goto st_string;
+		for (i = 0; i < LEN(escs); i++)
+			if (escs[i][0] == c) {
+				TOK(escs[i][1]);
+				goto st_string;
+			}
+		reportret(-2, "impossible escape");
 	} else {
 		if (escape_char)
 			reportret(-2, "escaped a non-escapable char");

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -4,7 +4,7 @@
 #define MAX_TOKS_PER_LINE 4096
 
 #define is_quote(C) (C && strchr("\"'`", C))
-#define is_eot(C) (C && strchr(" \t\n\r", C))
+#define is_eot(C) (C && strchr(" \t\n\r#", C))
 
 extern char tok_buf[TOK_MAX];
 

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -3,6 +3,9 @@
 #define TOK_MAX 4096
 #define MAX_TOKS_PER_LINE 4096
 
+#define is_quote(C) (C && strchr("\"'`", C))
+#define is_eot(C) (C && strchr(" \t\n\r", C))
+
 extern char tok_buf[TOK_MAX];
 
 void skip_newline(string_port *stream);

--- a/variables.c
+++ b/variables.c
@@ -15,6 +15,48 @@
 char varname[TOK_MAX];
 char *varerr;
 
+
+static int
+variable_character(char c)
+{
+	return c == '_' ||
+	       BETWEEN(c, 'A', 'Z') ||
+	       BETWEEN(c, 'a', 'z') ||
+	       BETWEEN(c, '0', '9');
+}
+
+static char *
+read_variable_prefix(char *tok)
+{
+	int pos = 0;
+	int brc = 0;
+
+	assert(*tok == '$');
+	tok++;
+
+	/* NOTE: We don't bother to bounds check here */
+	/* because tok is already <= the size of a token */
+	/* ...lets see if this ever bites? */
+
+	if (*tok == '{') {
+		brc = 1;
+		tok++;
+	}
+
+	while (variable_character(*tok))
+		varname[pos++] = *tok++;
+
+	if (brc && *tok++ != '}')
+		reportvar(varerr, "missing '}'");
+
+	varname[pos] = '\0';
+
+	if (!pos)
+		reportvar(varerr, "length 0 variable");
+
+	return tok;
+}
+
 char *
 expand_variables(region *r, char *tok, int t)
 {
@@ -48,45 +90,4 @@ expand_variables(region *r, char *tok, int t)
 	o[pos] = '\0';
 
 	return o;
-}
-
-int
-variable_character(char c)
-{
-	return c == '_' ||
-	       BETWEEN(c, 'A', 'Z') ||
-	       BETWEEN(c, 'a', 'z') ||
-	       BETWEEN(c, '0', '9');
-}
-
-char *
-read_variable_prefix(char *tok)
-{
-	int pos = 0;
-	int brc = 0;
-
-	assert(*tok == '$');
-	tok++;
-
-	/* NOTE: We don't bother to bounds check here */
-	/* because tok is already <= the size of a token */
-	/* ...lets see if this ever bites? */
-
-	if (*tok == '{') {
-		brc = 1;
-		tok++;
-	}
-
-	while (variable_character(*tok))
-		varname[pos++] = *tok++;
-
-	if (brc && *tok++ != '}')
-		reportvar(varerr, "missing '}'");
-
-	varname[pos] = '\0';
-
-	if (!pos)
-		reportvar(varerr, "length 0 variable");
-
-	return tok;
 }

--- a/variables.c
+++ b/variables.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <unistd.h>
 
 #include "region.h"
 #include "reporting.h"
@@ -15,6 +16,20 @@
 char varname[TOK_MAX];
 char *varerr;
 
+void
+vars_set(char **argv)
+{
+	int i = 0;
+	char var[8];
+	/* char varcat[ARG_MAX_STRLEN]; */
+	long max = sysconf(_SC_ARG_MAX);
+
+	for (argv++; *argv && i < max; argv++, i++) {
+		sprintf(var, "%d", i);
+		setenv(var, *argv, 1);
+	}
+	setenv("#", var, 1);
+}
 
 static int
 variable_character(char c)
@@ -43,7 +58,7 @@ read_variable_prefix(char *tok)
 		tok++;
 	}
 
-	while (variable_character(*tok))
+	while (variable_character(*tok) || (!pos && *tok == '#'))
 		varname[pos++] = *tok++;
 
 	if (brc && *tok++ != '}')

--- a/variables.c
+++ b/variables.c
@@ -16,6 +16,7 @@
 char varname[TOK_MAX];
 char *varerr;
 
+/* set positional variables before loading file */
 void
 vars_set(char **argv)
 {
@@ -29,6 +30,22 @@ vars_set(char **argv)
 		setenv(var, *argv, 1);
 	}
 	setenv("#", var, 1);
+}
+
+/* remove positional variables to prevent leakage */
+void
+vars_unset(void)
+{
+	int i = 0;
+	char var[8];
+	long max = sysconf(_SC_ARG_MAX);
+
+	for (; i < max; i++) {
+		sprintf(var, "%d", i);
+		if (!getenv(var)) break;
+		unsetenv(var);
+	}
+	unsetenv("#");
 }
 
 static int

--- a/variables.h
+++ b/variables.h
@@ -2,4 +2,5 @@
 
 extern char variable_name[TOK_MAX];
 
+void vars_set(char **argv);
 char *expand_variables(region *r, char *tok, int t);

--- a/variables.h
+++ b/variables.h
@@ -2,6 +2,4 @@
 
 extern char variable_name[TOK_MAX];
 
-char *read_variable_prefix(char *tok);
-int variable_character(char c);
 char *expand_variables(region *r, char *tok, int t);

--- a/variables.h
+++ b/variables.h
@@ -3,4 +3,5 @@
 extern char variable_name[TOK_MAX];
 
 void vars_set(char **argv);
+void vars_unset(void);
 char *expand_variables(region *r, char *tok, int t);


### PR DESCRIPTION
- Add positional parameters
  - `$1 $2 ...` set to any arguments passed
  - `$#` set to number of arguments
  - `$0` set to name of shell or script
  - Add test
  - Fix #8
- Fix memory leaks
  - `fopen` in `main()` and `builtin_source` now closed in `interpreter_loop()`
- Simplify `tokenizer.c`
  - Use array for escapes
  - Use `strchr()` in macro for `token_end()` and `is_quote_char()`
- Use `basename()` for `argv0`
- Report errors in `stringport.c`
- Make `string_port`'s `kind` an `enum`
- Make more functions `static`